### PR TITLE
docstring interactive notebook

### DIFF
--- a/notebooks/docstring_error_interactive.ipynb
+++ b/notebooks/docstring_error_interactive.ipynb
@@ -1,0 +1,452 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import ipywidgets as widgets\n",
+    "from ipywidgets import *\n",
+    "from bqplot import *\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import qgrid\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib notebook\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 1. Plots a bar graph representing the number of docstring errors.\n",
+    "\n",
+    "To generate the file in `json` format, the following command needs to be executed in `master` branch clone of pandas,\n",
+    "after completing the development environment setup.\n",
+    "\n",
+    "`./scripts/validate_docstrings.py --format=json > /path/to/json/pandas_docstring_errors.json`\n",
+    "\n",
+    "This script currently supports pandas version >= 0.25.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>index</th>\n",
+       "      <th>errors</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>pandas.Categorical</td>\n",
+       "      <td>[PR01, Parameters {fastpath} not documented]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>pandas.Categorical</td>\n",
+       "      <td>[PR09, Parameter \"dtype\" description should fi...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                index                                             errors\n",
+       "0  pandas.Categorical       [PR01, Parameters {fastpath} not documented]\n",
+       "1  pandas.Categorical  [PR09, Parameter \"dtype\" description should fi..."
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "path = '../json/pandas_docstring_errors.json.zip'\n",
+    "df = (pd.read_json(path, compression='zip')\n",
+    "            .transpose()\n",
+    "            .filter(items=['errors'])\n",
+    "            .explode('errors')\n",
+    "            .dropna()\n",
+    "            .reset_index()\n",
+    "     )\n",
+    "df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1) Split a list 'error' into separate data columns 'error_code' and 'error_name'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>error_code</th>\n",
+       "      <th>error_name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>PR01</td>\n",
+       "      <td>Parameters {fastpath} not documented</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>PR09</td>\n",
+       "      <td>Parameter \"dtype\" description should finish wi...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  error_code                                         error_name\n",
+       "0       PR01               Parameters {fastpath} not documented\n",
+       "1       PR09  Parameter \"dtype\" description should finish wi..."
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[['error_code','error_name']] = pd.DataFrame(df.errors.tolist(), index=df.index)\n",
+    "df = df.drop([\"errors\",\"index\"], axis=1)\n",
+    "df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2) Make a table to count the number of error_codes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>error_code</th>\n",
+       "      <th>counts</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>GL08</td>\n",
+       "      <td>517</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>PR09</td>\n",
+       "      <td>459</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  error_code  counts\n",
+       "0       GL08     517\n",
+       "1       PR09     459"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_code = df['error_code'].value_counts().reset_index()\n",
+    "df_code.columns = ['error_code','counts']\n",
+    "df_code.head(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 2. Interactive controls "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_output=widgets.Output()\n",
+    "count_output= widgets.Output()\n",
+    "error_output=widgets.Output()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ALL = 'ALL'\n",
+    "def unique_sorted_values_plus_ALL(array):\n",
+    "    unique = array.unique().tolist()\n",
+    "    unique.sort()\n",
+    "    unique.insert(0, ALL)\n",
+    "    return unique\n",
+    "\n",
+    "# 1.1) define a widget\n",
+    "dropdown_code = widgets.Dropdown(options = unique_sorted_values_plus_ALL(df_code.error_code))\n",
+    "\n",
+    "# 1.2) Define a qgrid widget\n",
+    "\n",
+    "col_opts = { 'editable': False}\n",
+    "qgrid.set_grid_option('maxVisibleRows', 10)\n",
+    "qgrid_widget = qgrid.show_grid(df, \n",
+    "                               column_options=col_opts,\n",
+    "                               show_toolbar=False)\n",
+    "qgrid_widget.layout = widgets.Layout(width='800px')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 2) use widget output to update tables/plots\n",
+    "def data_filtering(code):\n",
+    "    count_output.clear_output()\n",
+    "    plot_output.clear_output()\n",
+    "    error_output.clear_output()\n",
+    "    # 1.1 if no filtering\n",
+    "    if (code ==ALL):\n",
+    "        count_filter = df_code\n",
+    "        error_filter = df\n",
+    "    # 1.2 filter by code\n",
+    "    else:\n",
+    "        count_filter = df_code[df_code.error_code ==code]\n",
+    "        error_filter = df[df.error_code ==code]\n",
+    "    # 2.1 plot_output\n",
+    "    with plot_output:\n",
+    "        sns.set(style='whitegrid')\n",
+    "        ax=sns.barplot(x='error_code', y='counts', data=count_filter)\n",
+    "        plt.xticks(rotation=45)\n",
+    "        plt.xlabel('')\n",
+    "        plt.ylabel('Counts')\n",
+    "        plt.show()\n",
+    "    # 2.2 capture table output\n",
+    "    with count_output:\n",
+    "        display(count_filter)\n",
+    "   # 2.3 error_output\n",
+    "    with error_output:\n",
+    "        display(qgrid.show_grid(error_filter, column_options=col_opts,show_toolbar=False))\n",
+    "        #qgrid_widget.observe(on_row_selected, names=['_selected_rows'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 3) capture widget output\n",
+    "def dropdown_code_eventhandler(change):\n",
+    "    data_filtering(change.new)\n",
+    "\n",
+    "def qgrid_widget_eventhandler(change):\n",
+    "    data_filtering(change.new)    \n",
+    "    \n",
+    "dropdown_code.observe(dropdown_code_eventhandler, names='value')\n",
+    "\n",
+    "qgrid_widget.observe(qgrid_widget_eventhandler, names='value')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 4) Add widget in dashboard layout\n",
+    "input_widgets = widgets.HBox([dropdown_code])\n",
+    "\n",
+    "# 5) Create a container for the output\n",
+    "tab = widgets.Tab([ plot_output,count_output, error_output])\n",
+    "tab.set_title(0, 'Bar Plot')\n",
+    "tab.set_title(1, 'Error code Count')\n",
+    "tab.set_title(2, 'Error details')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dd7f37e010eb4090a289c9945138bee5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(Dropdown(options=('ALL', 'EX02', 'EX03', 'GL01', 'GL02', 'GL08', 'PR01', 'PR02',…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# 6) Stack a dashboard\n",
+    "dashboard = widgets.VBox([input_widgets, tab])\n",
+    "display(dashboard)\n",
+    "\n",
+    "# Select an error code from the dropdown then check the three tabs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Deploy the notebook on Binder\n",
+    "\n",
+    "e.g. check this notebook deployed on Binder from my personal repo \n",
+    "\n",
+    "https://mybinder.org/v2/gh/dujm/test-pddocs-demo/master?filepath=docstring_error_interactive.ipynb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Turn the notebook into an app using voila\n",
+    "#### In your terminal, run\n",
+    " * Create a conda environment  \n",
+    "`\n",
+    "conda env create\n",
+    "conda activate pandas-docs`\n",
+    "\n",
+    " * Render a notebook as an interactive notebook using voila|\n",
+    "   * 1) Default: render a notebook as a standalone application without source code  \n",
+    "`voila voila/notebooks/basics.ipynb`  \n",
+    "\n",
+    "   * 2) If you want to show the source code  \n",
+    "`voila voila/notebooks/basics.ipynb --strip_sources=False\n",
+    "`\n",
+    " * Open http://localhost:8866/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Related to #152. 
This is a Jupyter notebook with interactive controls.
- [x] including a dashboard widget for docstring errors 
- [x] the dashboard can be further turned into a local app using voila

After merging, the notebook can be further deployed 
- [ ] as an interactive notebook on Binder, [example](https://mybinder.org/v2/gh/dujm/test-pddocs-demo/master?filepath=docstring_error_interactive.ipynb)
- [ ] as an independent app on `TBD`



