### PR TITLE
add pelican content in blog/

### DIFF
--- a/blog/Makefile
+++ b/blog/Makefile
@@ -1,0 +1,82 @@
+PY?=python3
+PELICAN?=pelican
+PELICANOPTS=
+
+BASEDIR=$(CURDIR)
+INPUTDIR=$(BASEDIR)/content
+OUTPUTDIR=$(BASEDIR)/home
+CONFFILE=$(BASEDIR)/pelicanconf.py
+PUBLISHCONF=$(BASEDIR)/publishconf.py
+
+GITHUB_PAGES_BRANCH=gh-pages
+
+
+DEBUG ?= 0
+ifeq ($(DEBUG), 1)
+	PELICANOPTS += -D
+endif
+
+RELATIVE ?= 0
+ifeq ($(RELATIVE), 1)
+	PELICANOPTS += --relative-urls
+endif
+
+help:
+	@echo 'Makefile for a pelican Web site                                           '
+	@echo '                                                                          '
+	@echo 'Usage:                                                                    '
+	@echo '   make html                           (re)generate the web site          '
+	@echo '   make clean                          remove the generated files         '
+	@echo '   make regenerate                     regenerate files upon modification '
+	@echo '   make publish                        generate using production settings '
+	@echo '   make serve [PORT=8000]              serve site at http://localhost:8000'
+	@echo '   make serve-global [SERVER=0.0.0.0]  serve (as root) to $(SERVER):80    '
+	@echo '   make devserver [PORT=8000]          serve and regenerate together      '
+	@echo '   make ssh_upload                     upload the web site via SSH        '
+	@echo '   make rsync_upload                   upload the web site via rsync+ssh  '
+	@echo '   make github                         upload the web site via gh-pages   '
+	@echo '                                                                          '
+	@echo 'Set the DEBUG variable to 1 to enable debugging, e.g. make DEBUG=1 html   '
+	@echo 'Set the RELATIVE variable to 1 to enable relative urls                    '
+	@echo '                                                                          '
+
+html:
+	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
+
+clean:
+	[ ! -d $(OUTPUTDIR) ] || rm -rf $(OUTPUTDIR)
+
+regenerate:
+	$(PELICAN) -r $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
+
+serve:
+ifdef PORT
+	$(PELICAN) -l $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS) -p $(PORT)
+else
+	$(PELICAN) -l $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
+endif
+
+serve-global:
+ifdef SERVER
+	$(PELICAN) -l $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS) -p $(PORT) -b $(SERVER)
+else
+	$(PELICAN) -l $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS) -p $(PORT) -b 0.0.0.0
+endif
+
+
+devserver:
+ifdef PORT
+	$(PELICAN) -lr $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS) -p $(PORT)
+else
+	$(PELICAN) -lr $(INPUTDIR) -o $(OUTPUTDIR) -s $(CONFFILE) $(PELICANOPTS)
+endif
+
+publish:
+	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(PUBLISHCONF) $(PELICANOPTS)
+
+github: publish
+	ghp-import -m "Generate Pelican site" -b $(GITHUB_PAGES_BRANCH) $(OUTPUTDIR)
+	git push origin $(GITHUB_PAGES_BRANCH)
+
+
+.PHONY: html help clean regenerate serve serve-global devserver publish github

--- a/blog/content/build-website.md
+++ b/blog/content/build-website.md
@@ -1,0 +1,92 @@
+Title: Build a blog using Pelican
+Date: 2019-09-08
+Category: Tools
+Tags: Pelican
+
+## What is Pelican?
+Pelican is a Python library that lets you generate static websites from templates.
+
+## 1. Make a directory to host your site files
+```
+cd pandas-mentoring
+mkdir blog
+cd blog
+```
+
+## 2. Generate the initial boilerplate
+```
+pelican-quickstart
+
+> Where do you want to create your new web site? [.]
+> What will be the title of this web site? Pandas Mentoring Blog
+> Who will be the author of this web site? Les Pandanistas
+> What will be the default language of this web site? [en]
+> Do you want to specify a URL prefix? e.g., https://example.com   (Y/n) Y
+> What is your URL prefix? (see above example; no trailing slash) https://python-sprints.github.io/pandas-mentoring
+> Do you want to enable article pagination? (Y/n) Y
+> How many articles per page do you want? [10]
+> What is your time zone? [Europe/Paris]
+> Do you want to generate a tasks.py/Makefile to automate generation and publishing? (Y/n) Y
+> Do you want to upload your website using FTP? (y/N) N
+> Do you want to upload your website using SSH? (y/N) N
+> Do you want to upload your website using Dropbox? (y/N) N
+> Do you want to upload your website using S3? (y/N) N
+> Do you want to upload your website using Rackspace Cloud Files? (y/N) N
+> Do you want to upload your website using GitHub Pages? (y/N) y
+> Is this your personal page (username.github.io)? (y/N) N
+Done. Your new project is available at localpath/pandas-mentoring/blog
+```
+
+## 3. Add content in a markdown file
+```
+vim content/build-blog.md
+```
+
+## 4. Generate and preview your site
+```
+pelican content
+pelican --listen
+# Navigate to http://localhost:8000/ in your browser.
+```
+
+## 5. Add a theme
+```
+# Choose a path for to clone pelican-themes directory (e.g. blog/)
+git clone --recursive https://github.com/getpelican/pelican-themes ../pelican-themes
+
+# Add a theme in the pelicanconf.py of your site (e.g. fishingbird/pelicanconf.py)
+THEME = '../pelican-themes/uikit'
+```
+
+## 7. Publish to your Github project page
+```
+# Open pelicanconf.py
+vim pelicanconf.py
+
+# Add your SITE_URL
+SITEURL = 'https://python-sprints.github.io/pandas-mentoring'
+
+# Save your file
+```
+```
+# Generate output
+pelican content -o output -s pelicanconf.py
+
+# Publish to GitHub using ghp-import
+ghp-import output -n
+
+# Push to gh-pages branch
+git push origin gh-pages
+```
+
+## 8. What are the files?
+  * Makefile - This file defines make commands that perform the most important tasks like generating your site and starting a local http server.
+  * pelicanconf.py - This file contains settings to customize your site.
+  * publishconf.py - This file contains settings that are only used when you’re ready to publish to the web.
+  * content/ - This folder is where you’ll put the templates and files that will be translated into the content of your site.
+  * output/ - This folder might not exist until you convert your content into html. By default, the translated website lands here.
+
+
+## 9. Reference
+  * [Tutorials](https://github.com/getpelican/pelican/wiki/Tutorials)
+  * [Documentation](https://docs.getpelican.com/en/stable/)

--- a/blog/content/build-website.md
+++ b/blog/content/build-website.md
@@ -51,7 +51,7 @@ pelican --listen
 
 ## 5. Add a theme
 ```
-# Choose a path for to clone pelican-themes directory (e.g. blog/)
+# Choose a path to clone pelican-themes directory (e.g. blog/)
 git clone --recursive https://github.com/getpelican/pelican-themes ../pelican-themes
 
 # Add a theme in the pelicanconf.py of your site (e.g. fishingbird/pelicanconf.py)
@@ -70,10 +70,10 @@ SITEURL = 'https://python-sprints.github.io/pandas-mentoring'
 ```
 ```
 # Generate output
-pelican content -o output -s pelicanconf.py
+pelican content -o home -s pelicanconf.py
 
 # Publish to GitHub using ghp-import
-ghp-import output -n
+ghp-import home -n
 
 # Push to gh-pages branch
 git push origin gh-pages
@@ -84,7 +84,7 @@ git push origin gh-pages
   * pelicanconf.py - This file contains settings to customize your site.
   * publishconf.py - This file contains settings that are only used when you’re ready to publish to the web.
   * content/ - This folder is where you’ll put the templates and files that will be translated into the content of your site.
-  * output/ - This folder might not exist until you convert your content into html. By default, the translated website lands here.
+  * home/ - This folder might not exist until you convert your content into html. By default, the translated website lands here.
 
 
 ## 9. Reference

--- a/blog/content/contributing.md
+++ b/blog/content/contributing.md
@@ -1,0 +1,129 @@
+Title:  How to contribute?
+Date: 2019-09-08
+Category: Contributing
+Tags: contributing 
+
+## Index
+1. [How to contribute? Step by step guide](#how-to-contribute?-step-by-step-guide)
+2. [PR conventions](#pr-conventions)
+3. [PR review rules](#pr-review-rules)
+4. [Issue guidelines](#issue-guidelines)
+5. [References](#references)
+
+## How to contribute? Step by step guide
+
+#### Terms
+  * Upstream: the repository from the `original_author`
+  * Origin: the forked repository under your `account`
+
+#### 1. Fork a `project` to your GitHub `account`
+
+#### 2. Clone the `project` to your local environment
+```
+    git clone git@github.com:account/project.git
+    cd project
+```
+
+#### 3. Set up the origin and upstream of the your local `project`
+```  
+   #  Add the "upstream" to your cloned repository
+    git remote add upstream git@github.com:original_author/project.git
+
+   # Add the "origin" to your cloned repository
+    git remote add origin git@github.com:account/project.git
+```
+
+#### 4. Synchronize with updates from the upstream
+```
+   # 1) Go to the "master" branch of your fork ("origin")
+    git checkout master
+
+   # 2) Fetch the commits from the "upstream"
+    git fetch upstream
+
+   # 3) If you have local changes, stash the changes of your "master" branch
+    git stash
+
+   # 4) Merge the changes from the "master" branch of the "upstream" into your the "master" branch of your "origin"
+    git merge upstream/master
+
+   # 5) Resolve merge conflicts if any and commit your merge
+    git commit -m "Merged from upstream"
+
+   # 6) Push the changes to your fork ("origin")
+    git push
+
+   # 7) Get back your stashed changes (if any)
+    git stash pop
+```
+
+#### 5. Do your work in a `new-branch` of your origin
+```
+   # 1) Add a new branch from your origin/master branch
+   git branch new-branch origin/master
+   git checkout new-branch
+
+   # 2) Make a commit of your work (e.g. you added your name in the README.md)
+   git add README.md
+   git commit -m 'add my name'
+
+   # 3) If you had multiple commits, but you want to select a specific commit(e.g. commit id: bbb909f) for a pull request
+   git cherry-pick bbb909f
+
+   # 4) Push to your new-branch
+   git push origin new-branch
+```
+
+#### 6. Send a pull request on GitHub
+ * Go to the `new-branch` of your forked `project`
+ * Click `Compare & pull request`
+ * Leave a comment
+   * If you are solving an issue (e.g. `#17`), add `Closes #17` in the comment, the issue will automatically be closed when the pull request is merged.
+
+#### 7. Delete branch locally and/or remotely after pull request is merged on GitHub
+ * Deleting your local branch from the command line: `git branch -d new-branch`
+ * Additionally if you want to delete your remote branch: `git push origin : new-branch`
+
+## PR conventions
+When submitting a PR, please add one of the following prefixes depending on the topic you are addressing:
+
+    [ENH]: Enhancement, new functionality
+    [BUG]: Bug fix
+    [DOC]: Additions/updates to documentation
+    [TST]: Additions/updates to tests
+    [BLD]: Updates to the build process/scripts
+    [PERF]: Performance improvement
+    [CLN]: Code cleanup
+
+In addition:
+- Please reference the relevant GitHub issues in your commit message using GH1234 or #1234.
+- Include a subject line with < 80 chars.
+- Optionally, include a commit message body, leaving one blank line with the subject line.
+
+## PR review rules
+ * Input from two reviewers is needed to merge a pull request. One reviewer approves the merge and the other reviewer merges the pull request.
+
+## Issue guidelines
+
+### New issue
+Discovering an issue is great, here's what you need to do when you discover an issue:
+* Search if the issue has already been created.
+* If yes and open refer to existing issue.
+* If yes and closed reopen issue with descriptive comment.
+* If no, create the issue by:
+   * Following our issue [template.](https://github.com/pandas-dev/pandas/blob/master/.github/ISSUE_TEMPLATE.md)
+
+### Existing issue
+* Read comments.
+* Find out if anyone is working on it, if no, offer to do it. If yes, see if you can be of help.
+
+### Reporting bugs
+* Give information about the version and the operating system you are running.
+* Show the steps to reproduce bug.
+* Add log.
+
+## References
+* [GitHub forking](https://gist.github.com/Chaser324/ce0505fbed06b947d962)  
+* [Git cherry-pick](https://git-scm.com/docs/git-cherry-pick)
+* [Pandas contributing guides](https://pandas.pydata.org/pandas-docs/stable/development/contributing.html)
+* To read more tips on how to open issues, PRs and do code reviews, read the things we have been learning throughout the mentoring program [here](https://github.com/python-sprints/pandas-mentoring/blob/master/LEARNING_POINTS.md).

--- a/blog/pelicanconf.py
+++ b/blog/pelicanconf.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*- #
+from __future__ import unicode_literals
+
+AUTHOR = 'Les Pandanistas'
+SITENAME = 'Blog'
+SITEURL = 'https://python-sprints.github.io/pandas-mentoring'
+PATH = 'content'
+OUTPUT_PATH = 'home'
+TIMEZONE = 'Europe/Paris'
+
+DEFAULT_LANG = 'en'
+
+# Feed generation is usually not desired when developing
+FEED_ALL_ATOM = None
+CATEGORY_FEED_ATOM = None
+TRANSLATION_FEED_ATOM = None
+AUTHOR_FEED_ATOM = None
+AUTHOR_FEED_RSS = None
+
+# Blogroll
+LINKS = (('Pandas', 'https://pandas-docs.github.io/pandas-docs-travis/'),
+        ('Python Sprints', 'https://python-sprints.github.io/'),)
+
+# Social widget
+SOCIAL = (('github', 'https://github.com/python-sprints/pandas-mentoring'),)
+
+DEFAULT_PAGINATION = 10
+
+# Uncomment following line if you want document-relative URLs when developing
+#RELATIVE_URLS = True
+
+# Add a theme
+THEME = '../pelican-themes/uikit'
+DISPLAY_TAGS_ON_SIDEBAR_LIMIT = 0
+DISPLAY_LINKS_ON_SIDEBAR_LIMIT = 0
+LICENSE = {
+    'cc_name':"by-sa",
+    'hosted':False,
+    'compact':True,
+    'brief':False
+    }
+AUTHOR_IMAGE = u'logo.jpeg'

--- a/blog/pelicanconf.py
+++ b/blog/pelicanconf.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 AUTHOR = 'Les Pandanistas'
 SITENAME = 'Blog'
-SITEURL = 'https://python-sprints.github.io/pandas-mentoring'
+#SITEURL = 'https://python-sprints.github.io/pandas-mentoring'
 PATH = 'content'
 OUTPUT_PATH = 'home'
 TIMEZONE = 'Europe/Paris'
@@ -35,9 +35,9 @@ THEME = '../pelican-themes/uikit'
 DISPLAY_TAGS_ON_SIDEBAR_LIMIT = 0
 DISPLAY_LINKS_ON_SIDEBAR_LIMIT = 0
 LICENSE = {
-    'cc_name':"by-sa",
-    'hosted':False,
-    'compact':True,
-    'brief':False
+    'cc_name': "by-sa",
+    'hosted': False,
+    'compact': True,
+    'brief': False
     }
-AUTHOR_IMAGE = u'logo.jpeg'
+AUTHOR_IMAGE = '../img/logo.jpeg'

--- a/blog/publishconf.py
+++ b/blog/publishconf.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*- #
+from __future__ import unicode_literals
+
+# This file is only used if you use `make publish` or
+# explicitly specify it as your config file.
+
+import os
+import sys
+sys.path.append(os.curdir)
+from pelicanconf import *
+
+# If your site is available via HTTPS, make sure SITEURL begins with https://
+SITEURL = 'https://python-sprints.github.io/pandas-mentoring'
+RELATIVE_URLS = False
+
+FEED_ALL_ATOM = 'feeds/all.atom.xml'
+CATEGORY_FEED_ATOM = 'feeds/{slug}.atom.xml'
+
+DELETE_OUTPUT_DIRECTORY = True
+
+# Following items are often useful when publishing
+
+#DISQUS_SITENAME = ""
+#GOOGLE_ANALYTICS = ""

--- a/blog/tasks.py
+++ b/blog/tasks.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+
+import os
+import shutil
+import sys
+import datetime
+
+from invoke import task
+from invoke.util import cd
+from pelican.server import ComplexHTTPRequestHandler, RootedHTTPServer
+from pelican.settings import DEFAULT_CONFIG, get_settings_from_file
+
+SETTINGS_FILE_BASE = 'pelicanconf.py'
+SETTINGS = {}
+SETTINGS.update(DEFAULT_CONFIG)
+LOCAL_SETTINGS = get_settings_from_file(SETTINGS_FILE_BASE)
+SETTINGS.update(LOCAL_SETTINGS)
+
+CONFIG = {
+    'settings_base': SETTINGS_FILE_BASE,
+    'settings_publish': 'publishconf.py',
+    # Output path. Can be absolute or relative to tasks.py. Default: 'output'
+    'deploy_path': SETTINGS['OUTPUT_PATH'],
+    # Github Pages configuration
+    'github_pages_branch': 'gh-pages',
+    'commit_message': "'Publish site on {}'".format(datetime.date.today().isoformat()),
+    # Port for `serve`
+    'port': 8000,
+}
+
+@task
+def clean(c):
+    """Remove generated files"""
+    if os.path.isdir(CONFIG['deploy_path']):
+        shutil.rmtree(CONFIG['deploy_path'])
+        os.makedirs(CONFIG['deploy_path'])
+
+@task
+def build(c):
+    """Build local version of site"""
+    c.run('pelican -s {settings_base}'.format(**CONFIG))
+
+@task
+def rebuild(c):
+    """`build` with the delete switch"""
+    c.run('pelican -d -s {settings_base}'.format(**CONFIG))
+
+@task
+def regenerate(c):
+    """Automatically regenerate site upon file modification"""
+    c.run('pelican -r -s {settings_base}'.format(**CONFIG))
+
+@task
+def serve(c):
+    """Serve site at http://localhost:$PORT/ (default port is 8000)"""
+
+    class AddressReuseTCPServer(RootedHTTPServer):
+        allow_reuse_address = True
+
+    server = AddressReuseTCPServer(
+        CONFIG['deploy_path'],
+        ('', CONFIG['port']),
+        ComplexHTTPRequestHandler)
+
+    sys.stderr.write('Serving on port {port} ...\n'.format(**CONFIG))
+    server.serve_forever()
+
+@task
+def reserve(c):
+    """`build`, then `serve`"""
+    build(c)
+    serve(c)
+
+@task
+def preview(c):
+    """Build production version of site"""
+    c.run('pelican -s {settings_publish}'.format(**CONFIG))
+
+@task
+def livereload(c):
+    """Automatically reload browser tab upon file modification."""
+    from livereload import Server
+    build(c)
+    server = Server()
+    # Watch the base settings file
+    server.watch(CONFIG['settings_base'], lambda: build(c))
+    # Watch content source files
+    content_file_extensions = ['.md', '.rst']
+    for extension in content_file_extensions:
+        content_blob = '{0}/**/*{1}'.format(SETTINGS['PATH'], extension)
+        server.watch(content_blob, lambda: build(c))
+    # Watch the theme's templates and static assets
+    theme_path = SETTINGS['THEME']
+    server.watch('{}/templates/*.html'.format(theme_path), lambda: build(c))
+    static_file_extensions = ['.css', '.js']
+    for extension in static_file_extensions:
+        static_file = '{0}/static/**/*{1}'.format(theme_path, extension)
+        server.watch(static_file, lambda: build(c))
+    # Serve output path on configured port
+    server.serve(port=CONFIG['port'], root=CONFIG['deploy_path'])
+
+
+@task
+def publish(c):
+    """Publish to production via rsync"""
+    c.run('pelican -s {settings_publish}'.format(**CONFIG))
+    c.run(
+        'rsync --delete --exclude ".DS_Store" -pthrvz -c '
+        '{} {production}:{dest_path}'.format(
+            CONFIG['deploy_path'].rstrip('/') + '/',
+            **CONFIG))
+
+@task
+def gh_pages(c):
+    """Publish to GitHub Pages"""
+    preview(c)
+    c.run('ghp-import -b {github_pages_branch} '
+          '-m {commit_message} '
+          '{deploy_path} -p'.format(**CONFIG))


### PR DESCRIPTION
Close #159 


I add a `blog/` to host the content of pandas-mentoring website.

The website is generated using Pelican.

I plan to publish the html sites o `gh-pages branch`

